### PR TITLE
Removed Conflicting CSS To Render Roadmap Image Properly

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -102,7 +102,7 @@ function App() {
         </h2>
       </div>
 
-      <div className="flex lg:justify-around lg:mt-[5rem]  items-center  xxs:flex-col xxs:ml-2 md:mx-8 lg:flex-row ">
+      <div>
         <RoadMap />
       </div>
 


### PR DESCRIPTION
There was tailwind css styling on the Roadmap component in the App.js file, which was conflicting with Roadmap CSS, so I've removed it to properly render the Roadmap image, and now it's working fine.